### PR TITLE
Moar Int tests

### DIFF
--- a/customuser/test_integration.py
+++ b/customuser/test_integration.py
@@ -1,5 +1,3 @@
-import json
-
 from django.core.urlresolvers import reverse
 from django.forms.models import model_to_dict
 
@@ -13,7 +11,7 @@ class UserListTestCase(BaseAPITestCase):
         CustomUserFactory.create()
         response = self.client.get(reverse("user_list"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(json.loads(response.content.decode("utf-8"))), 1)
+        self.assertEqual(len(self.get_content(response)), 1)
 
 
 class UserUpdateTestCase(BaseAPITestCase):
@@ -26,8 +24,8 @@ class UserUpdateTestCase(BaseAPITestCase):
         response = self.client.post(
             reverse("user_update", kwargs={"pk": user.id}), data=payload)
         self.assertEqual(response.status_code, 200)
-        first_name = json.loads(response.content.decode("utf-8"))["first_name"]
-        self.assertEqual(first_name, payload["first_name"])
+        self.assertEqual(
+            self.get_content(response)["first_name"], payload["first_name"])
 
 
 class UserDetailTestCase(BaseAPITestCase):

--- a/linkfactory/test_integration.py
+++ b/linkfactory/test_integration.py
@@ -1,5 +1,3 @@
-import json
-
 from django.core.urlresolvers import reverse
 
 from .factories import LinkFactory, LinkTypeFactory
@@ -19,4 +17,4 @@ class LinkFactoryApiTestCase(BaseAPITestCase):
         self.authenticate()
         response = self.client.post(reverse("link_factory"), data=payload)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(json.loads(response.content.decode("utf-8"))), 1)
+        self.assertEqual(len(self.get_content(response)), 1)

--- a/misc/api.py
+++ b/misc/api.py
@@ -2,8 +2,6 @@ import re
 import urllib
 import requests
 import urllib.request
-import json
-# import random
 
 from opengraph import opengraph
 from rest_framework import status
@@ -12,13 +10,16 @@ from rest_framework.response import Response
 
 from rest_framework_jwt import utils
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.conf import settings
 from .serializers import UserSerializer
 
 from topics.models import Topic, Action
 from topics.serializers import TopicSerializer, ActionSerializer
+
+
+User = get_user_model()
 
 
 class UserRegistration(APIView):
@@ -102,16 +103,6 @@ class nyTimesAPIHelpers(APIView):
             return Response(response)
         except KeyError:
             return Response({"error": "invalid data"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-
-class geolocationHelpers(APIView):
-    def post(self, request, format=None):
-        gmapurl = 'http://maps.googleapis.com/maps/api/geocode/json?address=' + request.data['zip']
-        response = urllib.request.urlopen(gmapurl)
-        content = response.read()
-        data = json.loads(content.decode("utf8"))
-
-        return Response(data['results'][0]['geometry']['location'], status=status.HTTP_200_OK)
 
 
 def getTags(url):

--- a/misc/test_integration.py
+++ b/misc/test_integration.py
@@ -1,5 +1,3 @@
-import json
-
 from django.core.urlresolvers import reverse
 
 from customuser.factories import CustomUserFactory
@@ -41,5 +39,17 @@ class MiscApiTokenUserTestCase(BaseAPITestCase):
         user = self.authenticate()
         response = self.client.post(reverse("token_user"), data={})
         self.assertEqual(response.status_code, 200)
-        user_id = json.loads(response.content.decode("utf-8"))["user_id"]
+        user_id = self.get_content(response)["user_id"]
         self.assertEqual(user.id, user_id)
+
+
+class UserRegistrationTestCase(BaseAPITestCase):
+
+    def test_post_ok(self):
+        payload = {
+            "email": "test@test.com",
+            "username": "tester",
+            "password": "testerzz"
+        }
+        response = self.client.post(reverse("user_register"), data=payload)
+        self.assertEqual(response.status_code, 201)

--- a/topics/test_integration.py
+++ b/topics/test_integration.py
@@ -1,4 +1,3 @@
-import json
 import random
 
 from django.core.urlresolvers import reverse
@@ -23,8 +22,7 @@ class TopicApiCountTestCase(TopicApiTestCase):
     def test_get_ok(self):
         response = self.client.get(reverse("topic_count"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            1, json.loads(response.content.decode("utf-8"))["count"])
+        self.assertEqual(1, self.get_content(response)["count"])
 
 
 class TopicApiDeleteTestCase(TopicApiTestCase):
@@ -44,8 +42,8 @@ class TopicApiDetailTestCase(TopicApiTestCase):
         response = self.client.get(
             reverse("topic_detail", kwargs={"pk": self.topic.id}))
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(data["created_by"], self.topic.created_by.id)
+        self.assertEqual(
+            self.get_content(response)["created_by"], self.topic.created_by.id)
 
 
 class TopicApiListTestCase(TopicApiTestCase):
@@ -53,8 +51,7 @@ class TopicApiListTestCase(TopicApiTestCase):
     def test_get_ok(self):
         response = self.client.get(reverse("topic_list"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            1, len(json.loads(response.content.decode("utf-8"))))
+        self.assertEqual(1, len(self.get_content(response)))
 
 
 class TopicApiTagListTestCase(TopicApiTestCase):
@@ -66,8 +63,7 @@ class TopicApiTagListTestCase(TopicApiTestCase):
         response = self.client.get(
             reverse("topic_tag_list", kwargs={"tag": name}))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            1, len(json.loads(response.content.decode("utf-8"))))
+        self.assertEqual(1, len(self.get_content(response)))
 
 
 class TopicApiUpdateTestCase(TopicApiTestCase):
@@ -81,8 +77,7 @@ class TopicApiUpdateTestCase(TopicApiTestCase):
             reverse("topic_update", kwargs={"pk": self.topic.id}),
             data=payload)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(data["title"], new_title)
+        self.assertEqual(self.get_content(response)["title"], new_title)
 
 
 class TopicListByUser(TopicApiTestCase):

--- a/topics/test_integration.py
+++ b/topics/test_integration.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 from django.core.urlresolvers import reverse
 
@@ -10,6 +11,8 @@ from untitled.testing import BaseAPITestCase
 class TopicApiTestCase(BaseAPITestCase):
 
     def setUp(self):
+        # @todo this doesn't need to run on every test...
+        # use helpers instead
         image = self.create_test_image()
         self.user = CustomUserFactory.create()
         self.topic = TopicFactory.create(created_by=self.user, image=image)
@@ -80,3 +83,28 @@ class TopicApiUpdateTestCase(TopicApiTestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content.decode("utf-8"))
         self.assertEqual(data["title"], new_title)
+
+
+class TopicListByUser(TopicApiTestCase):
+
+    def test_get_ok(self):
+        response = self.client.get(
+            reverse("user_topics", kwargs={"pk": self.user.id}))
+        content = self.get_content(response)
+        self.assertEqual(len(content), 1)
+
+
+class TopicPost(TopicApiTestCase):
+
+    def test_post_ok(self):
+        payload = {
+            "article_link": "http://test.com/",
+            "scope": "something",
+            "scope": random.choice(["local", "national", "worldwide"]),
+            "title": "test",
+            "description": "testing",
+            "tags": '["test_tag"]'
+        }
+        self.authenticate()
+        response = self.client.post(reverse("topic_create"), data=payload)
+        self.assertEqual(response.status_code, 201)

--- a/untitled/testing.py
+++ b/untitled/testing.py
@@ -37,3 +37,6 @@ class BaseAPITestCase(APITestCase):
         image_file.seek(0)
         return InMemoryUploadedFile(
             image_file, None, name, "image/png", sys.getsizeof(image_file), None)
+
+    def get_content(self, response):
+        json.loads(response.content.decode("utf-8"))

--- a/untitled/testing.py
+++ b/untitled/testing.py
@@ -39,4 +39,4 @@ class BaseAPITestCase(APITestCase):
             image_file, None, name, "image/png", sys.getsizeof(image_file), None)
 
     def get_content(self, response):
-        json.loads(response.content.decode("utf-8"))
+        return json.loads(response.content.decode("utf-8"))


### PR DESCRIPTION
OK, I had to change misc/api.py. The code was attempting to create a `django.auth.contrib.models.User` instead of a `CustomUser`. This failed my tests, and I checked the frontend code and it's hitting that endpoint. Does that process work on the frontend before this update? It definitely shouldn't. If that flow works from your end, without this update, then something is amiss and we'll have to chat about it.